### PR TITLE
Fix permission re-prompt loop between tracker and UI instances

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2726,7 +2726,7 @@ dependencies = [
 
 [[package]]
 name = "zellij-project-switcher-plugin"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "criterion",
  "nu-ansi-term",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zellij-project-switcher-plugin"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2018"
 authors = ["Ian Davies <idavies@leapingfrogs.com>"]
 

--- a/src/bin/zellij-project-switcher-plugin.rs
+++ b/src/bin/zellij-project-switcher-plugin.rs
@@ -351,9 +351,16 @@ impl ZellijPlugin for State {
                 EventType::SessionUpdate,
                 EventType::PermissionRequestResult,
             ]);
+            // Must request the SAME permission set as the UI mode below, even
+            // though the tracker never runs commands: zellij rewrites the
+            // cached grant with exactly the requested set on every load
+            // (including silent cached grants), so requesting a subset here
+            // would strip RunCommands from the cache each time a session
+            // starts and re-prompt on the next UI open, forever.
             request_permission(&[
                 PermissionType::ReadApplicationState,
                 PermissionType::ChangeApplicationState,
+                PermissionType::RunCommands,
             ]);
             return;
         }


### PR DESCRIPTION
## Summary
Fixes the repeated permission prompts reported when using the 0.3.1 session tracker alongside the switcher UI.

**Root cause** (verified in zellij 0.44.3 source): zellij rewrites a plugin URL's cached grant with *exactly the requested permission set* on every load — including silent cached grants (`PluginInstruction::PermissionRequestResult` unconditionally calls `cache_plugin_permissions`, and `PermissionCache::cache` is a HashMap insert, i.e. a full replace). The tracker requested only `ReadApplicationState` + `ChangeApplicationState`, so every new session's tracker silently stripped `RunCommands` from the cache, and the next UI open re-prompted. Granting restored 3 permissions, the next tracker load stripped them again — an indefinite loop.

**Fix**: request the identical three-permission set in tracker mode, making zellij's rewrite a no-op. The tracker never actually runs commands; the extra grant is inert.

Worth filing upstream: zellij's silent-grant path could merge rather than replace the cached set.

## Test plan
- [x] All 36 tests pass on `wasm32-wasip1`; clippy pedantic clean
- [x] Cache-entry inspection confirms the clobber-and-reprompt cycle matches the reported symptom exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)